### PR TITLE
Return the found variables in messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,21 @@
 [ci]: https://travis-ci.org/princed/postcss-modules-values-replace
 [ci-img]:  https://travis-ci.org/princed/postcss-modules-values-replace.svg
 [PostCSS]: https://github.com/postcss/postcss
-[css-loader]: https://github.com/webpack/css-loader 
-[postcss-calc]: https://github.com/postcss/postcss-calc 
+[css-loader]: https://github.com/webpack/css-loader
+[postcss-calc]: https://github.com/postcss/postcss-calc
 [postcss-cssnext]: https://github.com/MoOx/postcss-cssnext
 [postcss-color-function]: https://github.com/postcss/postcss-color-function
-[postcss-modules-values]: https://github.com/css-modules/postcss-modules-values 
+[postcss-modules-values]: https://github.com/css-modules/postcss-modules-values
 
 Replaces CSS Modules @values just as [postcss-modules-values] does, but without help of [css-loader],
-so it could be used before other [PostCSS] plugins like [postcss-calc]. 
+so it could be used before other [PostCSS] plugins like [postcss-calc].
 
 Example:
 
 ```css
 /* constants.css */
 @value unit: 8px;
-@value footer-height: calc(unit * 5); 
+@value footer-height: calc(unit * 5);
 
 /* my-components.css */
 @value unit, footer-height from "./constants.css";
@@ -33,26 +33,26 @@ Example:
 ```
 
 yields `my-components.css`:
- 
+
 ```css
  @value unit, footer-height from "./constants.css";
  @value component-height: calc(8px * 10);
- 
+
  .my-component {
    padding: 8px;
    margin-top: calc(8px * 5);
    height: calc(8px * 10);
  }
  ```
- 
+
 and leads to export of following values to JS:
 
 ```js
 {
     "unit": "8px",
-    "footer-height": "calc(8px * 5)",  
+    "footer-height": "calc(8px * 5)",
     "component-height": "calc(8px * 10)",
-    ...    
+    ...
 }
 ```
 
@@ -75,7 +75,7 @@ To make it faster in webpack pass its file system to plugin:
 }
 ```
 
-Or in `postcss.config.js` form: 
+Or in `postcss.config.js` form:
 
 ```js
 module.exports = (ctx) => ({
@@ -88,10 +88,10 @@ module.exports = (ctx) => ({
 
 See [PostCSS] docs for examples for your environment.
 
-### calc() and @value 
+### calc() and @value
 
 To enable calculations *inside* **@value**, enable media queries support in [postcss-calc]:
- 
+
 ```js
 postcss([
   require('postcss-modules-values-replace'),
@@ -99,7 +99,7 @@ postcss([
 ])
 ```
 
-or via [postcss-cssnext]: 
+or via [postcss-cssnext]:
 
 ```js
 postcss([
@@ -113,7 +113,7 @@ Example with `calc` enabled:
 ```css
 /* constants.css */
 @value unit: 8px;
-@value footer-height: calc(unit * 5); 
+@value footer-height: calc(unit * 5);
 
 /* my-components.css */
 @value unit, footer-height from "./constants.css";
@@ -127,33 +127,39 @@ Example with `calc` enabled:
 ```
 
 yields `my-components.css`:
- 
+
 ```css
  @value unit, footer-height from "./constants.css";
  @value component-height: 80px;
- 
+
  .my-component {
    padding: 8px;
    margin-top: 40px;
    height: 80px;
  }
  ```
- 
+
 and leads to export of following values to JS:
 
 ```js
 {
     "unit": "8px",
-    "footer-height": "40px",  
+    "footer-height": "40px",
     "component-height": "80px",
-    ...    
+    ...
 }
 ```
-  
-### Other computations and @value 
-  
-[postcss-color-function] and other plugins probably won't work *inside* **@value** as they don't traverse media queries.  
-  
+
+### Other computations and @value
+
+[postcss-color-function] and other plugins probably won't work *inside* **@value** as they don't traverse media queries.
+
+### Extracting values for programmatic use
+This plugin provides to postcss a custom [messages](http://api.postcss.org/Result.html#messages) object with `type: 'values'`.
+The `values` property of that object will contain all the extracted values with all substitution performed (i.e. for values that reference other values).
+
+See [modules-values-extract](https://github.com/alexhisen/modules-values-extract) for an example of how this can be used.
+
 ## Environment
 
 Node.js 6.5 or above is recomended.

--- a/index.js
+++ b/index.js
@@ -136,6 +136,10 @@ module.exports = postcss.plugin('postcss-modules-values-replace', ({ fs = nodeFs
 
 
   return walk(null, root, rootResult).then((definitions) => {
+    rootResult.messages.push({
+      type: INNER_PLUGIN,
+      value: definitions,
+    });
     replaceSymbols(root, definitions);
   });
 });

--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ const matchImports = /^(.+?|\([\s\S]+?\))\s+from\s+("[^"]*"|'[^']*'|[\w-]+)$/;
 const matchValueDefinition = /(?:\s+|^)([\w-]+)(:?\s+)(.+?)(\s*)$/g;
 const matchImport = /^([\w-]+)(?:\s+as\s+([\w-]+))?/;
 
+const PLUGIN = 'postcss-modules-values-replace';
 const INNER_PLUGIN = 'postcss-modules-values-replace-bind';
 const walkerPlugin = postcss.plugin(INNER_PLUGIN, (fn, context) => fn.bind(null, context));
 
-module.exports = postcss.plugin('postcss-modules-values-replace', ({ fs = nodeFs } = {}) => (root, rootResult) => {
+module.exports = postcss.plugin(PLUGIN, ({ fs = nodeFs } = {}) => (root, rootResult) => {
   const walkFile = (from, context) => new Promise((resolve, reject) => {
     fs.readFile(from, (err, content) => {
       if (err) {
@@ -137,8 +138,9 @@ module.exports = postcss.plugin('postcss-modules-values-replace', ({ fs = nodeFs
 
   return walk(null, root, rootResult).then((definitions) => {
     rootResult.messages.push({
-      type: INNER_PLUGIN,
-      value: definitions,
+      plugin: PLUGIN,
+      type: 'values',
+      values: definitions,
     });
     replaceSymbols(root, definitions);
   });

--- a/test.js
+++ b/test.js
@@ -257,3 +257,11 @@ test('should allow imported transitive values within calc', async (t) => {
   );
 });
 
+test('variables are also present in messages', async (t) => {
+  const input = '@value myColor: blue; @value myColor2: myColor';
+  const processor = postcss([plugin]);
+  const result = await processor.process(input);
+  const variables = result.messages[0].value;
+
+  t.is(variables.myColor2, 'blue');
+});

--- a/test.js
+++ b/test.js
@@ -261,7 +261,9 @@ test('variables are also present in messages', async (t) => {
   const input = '@value myColor: blue; @value myColor2: myColor';
   const processor = postcss([plugin]);
   const result = await processor.process(input);
-  const variables = result.messages[0].value;
+  const values = result.messages[0].values;
+  const type = result.messages[0].type;
 
-  t.is(variables.myColor2, 'blue');
+  t.is(type, 'values');
+  t.is(values.myColor2, 'blue');
 });


### PR DESCRIPTION
This allows programmatic use of postcss with this plugin to, for example, convert the module values to css custom properties to feed to cssnext in features.customProperties.variables.