### PR TITLE
Support removal of @value exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,34 @@ See [PostCSS] docs for other examples for your environment.
 
 ### Configuration params
 
-#### fs `Object` 
+#### fs `Object`
 
 File system to use. To make it faster in webpack pass its file system to plugin.
-Cached Node's file system is used by default. 
+Cached Node's file system is used by default.
 
 #### resolve `Object`
 
-[enhanced-resolve]'s configuration object, see there for possible options and defaults.  
+[enhanced-resolve]'s configuration object, see there for possible options and defaults.
+
+
+#### noEmitExports `boolean`
+
+When enabled @value rules/declarations will be removed from the emitted output
+
+**Input:**
+```css
+@value myBrandColor blue;
+@font-face {}
+
+body { background: myBrandColor }
+```
+
+**Output:**
+```css
+@font-face {}
+
+body { background: blue }
+```
 
 ### calc() and @value
 
@@ -154,7 +174,7 @@ and leads to export of following values to JS:
 ### Other computations and @value
 
 [postcss-calc] and [postcss-color-function] are known to work *inside* **@value** as they traverse media queries.
-Experience with other plugins may differ if they ignore media queries.  
+Experience with other plugins may differ if they ignore media queries.
 
 ### Extracting values for programmatic use
 This plugin provides to postcss a custom [messages](http://api.postcss.org/Result.html#messages) object with `type: 'values'`.

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ const factory = ({
     } else if (node.type === 'atrule' && node.name === 'media') {
       // eslint-disable-next-line no-param-reassign
       node.params = replaceValueSymbols(node.params, definitions);
-    } else if (noEmitExports && node.type === 'atrule') {
+    } else if (noEmitExports && node.type === 'atrule' && node.name === 'value') {
       node.remove();
     }
   });

--- a/index.js
+++ b/index.js
@@ -132,8 +132,15 @@ const walk = async (requiredDefinitions, walkFile, root, result) => {
 
 const walkerPlugin = postcss.plugin(INNER_PLUGIN, (fn, ...args) => fn.bind(null, ...args));
 
-const factory = ({ fs = nodeFs, resolve: options = {} } = {}) => async (root, rootResult) => {
-  const resolver = ResolverFactory.createResolver(Object.assign({ fileSystem: fs }, options));
+const factory = ({
+  fs = nodeFs,
+  noEmitExports = false,
+  resolve: resolveOptions = {},
+} = {}) => async (root, rootResult) => {
+  const resolver = ResolverFactory.createResolver(Object.assign(
+    { fileSystem: fs },
+    resolveOptions,
+  ));
   const resolve = promisify(resolver.resolve, resolver);
   const readFile = promisify(fs.readFile, fs);
 
@@ -160,6 +167,8 @@ const factory = ({ fs = nodeFs, resolve: options = {} } = {}) => async (root, ro
     } else if (node.type === 'atrule' && node.name === 'media') {
       // eslint-disable-next-line no-param-reassign
       node.params = replaceValueSymbols(node.params, definitions);
+    } else if (noEmitExports && node.type === 'atrule') {
+      node.remove();
     }
   });
 };

--- a/test.js
+++ b/test.js
@@ -26,6 +26,10 @@ test('should leave exports as is', async (t) => {
   await run(t, '@value red blue;', '@value red blue;');
 });
 
+test('should remove exports if noEmitExports is true', async (t) => {
+  await run(t, '@value red blue;', '', { noEmitExports: true });
+});
+
 test('gives an error when there is no semicolon between lines', async (t) => {
   const input = '@value red blue\n@value green yellow';
   const processor = postcss([plugin]);

--- a/test.js
+++ b/test.js
@@ -26,6 +26,10 @@ test('should leave exports as is', async (t) => {
   await run(t, '@value red blue;', '@value red blue;');
 });
 
+test('should leave other at rules alone if noEmitExports is true', async (t) => {
+  await run(t, '@font-face {}', '@font-face {}', { noEmitExports: true });
+});
+
 test('should remove exports if noEmitExports is true', async (t) => {
   await run(t, '@value red blue;', '', { noEmitExports: true });
 });


### PR DESCRIPTION
Hey @princed nice to see you here 😂 I saw the issue [here](https://github.com/princed/postcss-modules-values-replace/issues/27) as I was encountering a similar issue:

I am actually trying to use this plugin on a personal project without webpack - as simple as it gets: compiling some css via the `postcss` CLI. I'd like to be able to remove the exports at compilation. This adds a configurable option to do exactly this.