### PR TITLE
Add support for value replacement within rule selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ When enabled, permit plugins defined earlier in the PostCSS pipeline to modify `
 When enabled, value imports will be resolved as module requests, in line with `css-loader`'s resolution logic [as of 2.0.0](https://github.com/webpack-contrib/css-loader/blob/master/CHANGELOG.md#200-2018-12-07).
 If your code is written with pre-2.0 import syntax, and utilises [postcss-modules-tilda] for compatibility, this option is not required.
 
+#### replaceInSelectors `boolean`
+
+When enabled, value usage within rule selectors will also be replaced by this plugin.
+
 ### calc() and @value
 
 To enable calculations *inside* **@value**, enable media queries support in [postcss-calc]:

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const promisify = require('es6-promisify');
 const { CachedInputFileSystem, NodeJsInputFileSystem, ResolverFactory } = require('enhanced-resolve');
 const valuesParser = require('postcss-values-parser');
 const { urlToRequest } = require('loader-utils');
+const ICSSUtils = require('icss-utils');
 
 const matchImports = /^(.+?|\([\s\S]+?\))\s+from\s+("[^"]*"|'[^']*'|[\w-]+)$/;
 const matchValueDefinition = /(?:\s+|^)([\w-]+)(:?\s+)(.+?)(\s*)$/g;
@@ -186,7 +187,7 @@ const factory = ({
       node.params = replaceValueSymbols(node.params, definitions);
     } else if (replaceInSelectors && node.type === 'rule') {
       // eslint-disable-next-line no-param-reassign
-      node.selector = replaceValueSymbols(node.selector, definitions);
+      node.selector = ICSSUtils.replaceValueSymbols(node.selector, definitions);
     } else if (noEmitExports && node.type === 'atrule' && node.name === 'value') {
       node.remove();
     }

--- a/index.js
+++ b/index.js
@@ -139,6 +139,7 @@ const factory = ({
   resolve: resolveOptions = {},
   preprocessValues = false,
   importsAsModuleRequests = false,
+  replaceInSelectors = false,
 } = {}) => async (root, rootResult) => {
   const resolver = ResolverFactory.createResolver(Object.assign(
     { fileSystem: fs },
@@ -183,6 +184,9 @@ const factory = ({
     } else if (node.type === 'atrule' && node.name === 'media') {
       // eslint-disable-next-line no-param-reassign
       node.params = replaceValueSymbols(node.params, definitions);
+    } else if (replaceInSelectors && node.type === 'rule') {
+      // eslint-disable-next-line no-param-reassign
+      node.selector = replaceValueSymbols(node.selector, definitions);
     } else if (noEmitExports && node.type === 'atrule' && node.name === 'value') {
       node.remove();
     }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "enhanced-resolve": "^3.1.0",
     "es6-promisify": "^5.0.0",
+    "icss-utils": "^4.0.0",
     "loader-utils": "^2.0.0",
     "postcss": "^7.0.0",
     "postcss-values-parser": "^1.3.1"

--- a/test.js
+++ b/test.js
@@ -421,6 +421,15 @@ test('should resolve imports as module requests', async (t) => {
   );
 });
 
+test('should replace values within rule selectors', async (t) => {
+  await run(
+    t,
+    '@value selectorValue: .exampleClass;\nselectorValue a { color: purple; }',
+    '@value selectorValue: .exampleClass;\n.exampleClass a { color: purple; }',
+    { replaceInSelectors: true },
+  );
+});
+
 test('variables are also present in messages', async (t) => {
   const input = '@value myColor: blue; @value myColor2: myColor';
   const processor = postcss([plugin]);


### PR DESCRIPTION
heyo, it's me again!

[`postcss-modules-values`](https://github.com/css-modules/postcss-modules-values) supports `@value` replacement within rule selectors. Noticed that this plugin wasn't echoing the behaviour.

By permitting eager replacement of values in selectors, it unlocks usage of plugins that operate on selectors directly when values are in use.

Few notes on impl:

- I've pulled in [`icss-utils`](https://github.com/css-modules/icss-utils) for it's `replaceValueSymbols` function. This is the exact function used by `postcss-modules-values` for its own transformation, so it should match up 1:1. Despite the outdated readme, replacement within selector strings is [a tested feature](https://github.com/css-modules/icss-utils/blob/master/test/replaceValueSymbols.test.js#L60-L76). 
- I did consider adding an option to swap over to `icss-utils` for the entire replacement step, but it's unfortunately a little eager and replaces within `@value` rules as well, rendering them useless.
- `icss-utils` is pinned at `@^4.0.0` to prevent breaking change of peerdep on postcss 8.