### PR TITLE
feat: update dependencies to use postcss 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,18 @@
   "dependencies": {
     "enhanced-resolve": "^3.1.0",
     "es6-promisify": "^5.0.0",
-    "icss-utils": "^4.0.0",
+    "icss-utils": "^5.1.0",
     "loader-utils": "^2.0.0",
-    "postcss": "^7.0.0",
-    "postcss-values-parser": "^1.3.1"
+    "postcss-values-parser": "^6.0.2"
   },
   "devDependencies": {
     "ava": "^0.24.0",
     "eslint": "^4.15.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.5.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.2.9"
   },
   "scripts": {
     "lint": "eslint *.js",


### PR DESCRIPTION
Changes:
- Updated Postcss to version 8
- Updated code to use new API
- Update other dependencies so they use Postcss 8 as well
- Update tests to work with Postss 8

Fixes https://github.com/princed/postcss-modules-values-replace/issues/36 and fixes https://github.com/princed/postcss-modules-values-replace/issues/37