### PR TITLE
Allow processing of `@container` at-rule, add tests for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ If your code is written with pre-2.0 import syntax, and utilises [postcss-module
 
 When enabled, value usage within rule selectors will also be replaced by this plugin.
 
+#### atRules `Array<string>`
+
+You can pass a list of at-rules in which `@value`'s should be replaced. Only `@media` rules will be processed by default.
+Note that passed array isn't merged with default `['media']` but overwrites it, so you'll need to include all the rules you want to be processed.
+
+```js
+postcss([
+  require('postcss-modules-values-replace')({ atRules: ['media', 'container']  })
+]);
+```
+**Input:**
+```css
+@value $tables from './breakpoints.css';
+
+@container (width >= $tablet) {}
+```
+
+**Output:**
+```css
+@container (width >= 768px) {}
+```
+
 ### calc() and @value
 
 To enable calculations *inside* **@value**, enable media queries support in [postcss-calc]:

--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ const factory = ({
   preprocessValues = false,
   importsAsModuleRequests = false,
   replaceInSelectors = false,
+  atRules = ['media']
 } = {}) => ({
   postcssPlugin: PLUGIN,
   prepare(rootResult) {
@@ -206,10 +207,13 @@ const factory = ({
         node.value = replaceValueSymbols(node.value, definitions);
       },
       AtRule: {
-        media(node) {
-          // eslint-disable-next-line no-param-reassign
-          node.params = replaceValueSymbols(node.params, definitions);
-        },
+        ...atRules.reduce((acc, atRule) => ({
+          ...acc,
+          [atRule]: (node) => {
+            // eslint-disable-next-line no-param-reassign
+            node.params = replaceValueSymbols(node.params, definitions);
+          },
+        }), {}),
         value(node) {
           if (noEmitExports) {
             node.remove();

--- a/index.test.js
+++ b/index.test.js
@@ -263,11 +263,29 @@ test('should replace inside custom properties', async (t) => {
   );
 });
 
-test('should replace inside media queries', async (t) => {
+test('should replace inside media queries by default, without specifying custom at-rules', async (t) => {
   await run(
     t,
     '@value base: 10px;\n@media (min-width: calc(base * 200)) {}',
     '@value base: 10px;\n@media (min-width: calc(10px * 200)) {}',
+  );
+});
+
+test('should replace inside media queries when it is specified as a custom at-rule', async (t) => {
+  await run(
+    t,
+    '@value base: 10px;\n@media (min-width: calc(base * 200)) {}',
+    '@value base: 10px;\n@media (min-width: calc(10px * 200)) {}',
+    { atRules: ['media'] }
+  );
+});
+
+test('should replace inside media and container queries when they are specified as a custom at-rules', async (t) => {
+  await run(
+    t,
+    '@value base: 10px;\n@media (min-width: calc(base * 200)) {}\n@container (min-width: calc(base * 200)) {}',
+    '@value base: 10px;\n@media (min-width: calc(10px * 200)) {}\n@container (min-width: calc(10px * 200)) {}',
+    { atRules: ['media', 'container'] }
   );
 });
 


### PR DESCRIPTION
Hello!

The name of PR is self-explanatory. My team uses this plugin for a large project, recently we've been updating our UI and tried to use `@container` rules. And found that the plugin doesn't update variable values inside them.

Here is a quick fix (we'll be grateful for shipping it ASAP 🙏), but generally it would be better to allow user to define which at-rules he wants to be supported. There are [a bunch](https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule) of them.

For example:

```javascript
// postcss.config.js 
postcss([
  require('postcss-modules-values-replace')({ atRules: ['media', 'container']  })
]);

// index.js in this repo
const defaultAtRules = ['media'];

const factory = ({
  atRules = defaultAtRules,
  // ...
  // ...
  AtRule: {
    ...atRules.reduce((acc, rule) => {
      acc[rule] = function(node) {
        // eslint-disable-next-line no-param-reassign
        node.params = replaceValueSymbols(node.params, definitions);
      }
    }, {}),
    value(node) {
      if (noEmitExports) {
        node.remove();
      }
    },
  },
  // ...

```

Cheers!