### PR TITLE
Warn on invalid `@value` definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const replaceValueSymbols = (valueString, replacements) => {
 const getDefinition = (atRule, existingDefinitions, requiredDefinitions) => {
   const matches = matchValueDefinition.exec(atRule.params);
   if (!matches) {
-    throw atRule.error('Invalid @value definition');
+    return null;
   }
 
   const [/* match */, name, middle, value, end] = matches;
@@ -115,6 +115,9 @@ const walk = async (requiredDefinitions, walkFile, root, result) => {
     }
 
     const newDefinitions = getDefinition(atRule, existingDefinitions, requiredDefinitions);
+    if (!newDefinitions) {
+      result.warn(`Invalid value definition: ${atRule.params}`);
+    }
     return Object.assign(existingDefinitions, newDefinitions);
   };
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,12 @@ const replaceValueSymbols = (valueString, replacements) => {
 };
 
 const getDefinition = (atRule, existingDefinitions, requiredDefinitions) => {
-  const [/* match */, name, middle, value, end] = matchValueDefinition.exec(atRule.params);
+  const matches = matchValueDefinition.exec(atRule.params);
+  if (!matches) {
+    throw atRule.error('Invalid @value definition');
+  }
+
+  const [/* match */, name, middle, value, end] = matches;
   const valueWithReplacements = replaceValueSymbols(value, existingDefinitions);
 
   if (!requiredDefinitions) {

--- a/index.test.js
+++ b/index.test.js
@@ -67,10 +67,16 @@ test('gives an error when path to imported file is wrong', async (t) => {
   await t.expect(processor.process(input, parserOpts)).rejects.toThrow("Can't resolve './non-existent-file.css'");
 });
 
-test('gives an error when @value statement is invalid', async (t) => {
+test('gives an error when @value import statement is invalid', async (t) => {
   const input = '@value , from "./colors.css"';
   const processor = postcss([plugin]);
   await t.expect(processor.process(input, parserOpts)).rejects.toThrow('@value statement "" is invalid!');
+});
+
+test('gives an error when @value declaration is invalid', async (t) => {
+  const input = '@value oops;';
+  const processor = postcss([plugin]);
+  await t.expect(processor.process(input, parserOpts)).rejects.toThrow('Invalid @value definition');
 });
 
 test('shouldn\'t break on draft spec syntax', async (t) => {

--- a/index.test.js
+++ b/index.test.js
@@ -51,7 +51,7 @@ test('should remove exports if noEmitExports is true', async (t) => {
   await run(t, '@value red blue;', '', { noEmitExports: true });
 });
 
-test('gives an error when there is no semicolon between lines', async (t) => {
+test('gives a warning when there is no semicolon between lines', async (t) => {
   const input = '@value red blue\n@value green yellow';
   const processor = postcss([plugin]);
   const result = await processor.process(input, { from: undefined });
@@ -59,6 +59,16 @@ test('gives an error when there is no semicolon between lines', async (t) => {
 
   t.expect(warnings.length).toBe(1);
   t.expect(warnings[0].text).toBe('Invalid value definition: red blue\n@value green yellow');
+});
+
+test('gives a warning when @value definition is invalid', async (t) => {
+  const input = '@value oops:;';
+  const processor = postcss([plugin]);
+  const result = await processor.process(input, { from: undefined });
+  const warnings = result.warnings();
+
+  t.expect(warnings.length).toBe(1);
+  t.expect(warnings[0].text).toBe('Invalid value definition: oops:');
 });
 
 test('gives an error when path to imported file is wrong', async (t) => {
@@ -71,12 +81,6 @@ test('gives an error when @value import statement is invalid', async (t) => {
   const input = '@value , from "./colors.css"';
   const processor = postcss([plugin]);
   await t.expect(processor.process(input, parserOpts)).rejects.toThrow('@value statement "" is invalid!');
-});
-
-test('gives an error when @value declaration is invalid', async (t) => {
-  const input = '@value oops;';
-  const processor = postcss([plugin]);
-  await t.expect(processor.process(input, parserOpts)).rejects.toThrow('Invalid @value definition');
 });
 
 test('shouldn\'t break on draft spec syntax', async (t) => {


### PR DESCRIPTION
Just noticed a flaw with my previous PR #56 - `RegExp.prototype.exec` will return null if no match is found. Previously this wouldn't cause an error since the `while` statement would skip if `matches` was null. Now it will throw a `TypeError: object null is not iterable` when destructuring the result.

This PR prevents this error, and instead emits a postcss warning if the `@value` statement couldn't be parsed. This matches the behavior of `postcss-modules-values` as described in [this test](https://github.com/css-modules/postcss-modules-values/blob/e7baeb0e533672c41b0df02bbfa7d8eb9b84f401/test/index.test.js#L31-L40).